### PR TITLE
Update to /etc/fstab

### DIFF
--- a/vignettes/b1-setting-up-and-using-rix-on-linux-and-windows.Rmd
+++ b/vignettes/b1-setting-up-and-using-rix-on-linux-and-windows.Rmd
@@ -147,7 +147,7 @@ the available space on your root partition is limited, we advise you to mount th
 hard drive). For this, edit `/etc/fstab` and add the following line at the end:
 
 ```
-/home/path_to/nix /nix none bind 0 0
+/nix /home/path_to/nix none bind 0 0
 ```
 
 This will map `/nix` to `/home/path_to/nix` which can be on a larger partition.


### PR DESCRIPTION
Order of `/etc/fstab` should be SOURCE > MOUNT POINT > FILE SYSTEM TYPE > OPTIONS > DUMP. New order is how I got it to correctly mount on `/home` . The previous line of code mounted an empy directory unto `/nix`.

## Metadata
|key|value|
|--|--|
|**version**|0.36.3|
|**os**|linux|
|**arch**|x86_64|